### PR TITLE
Incorporate DCIS incidence directly in function

### DIFF
--- a/NPI_by_size_sim_DCIS.R
+++ b/NPI_by_size_sim_DCIS.R
@@ -2,7 +2,7 @@
 #Updated 1010 include DCIS
 NPI_by_size <- function(Ca_size,screen_detected_ca){
   NPI_cat <- 0
-  if (runif(1,0,1)<0.21 && screen_detected_ca == 1){
+  if (runif(1,0,1)<DCIS_fraction && screen_detected_ca == 1){
     NPI_cat <-4
   }
 #first determine if advanced cancer or not based on metastatic prob by size (categorical)


### PR DESCRIPTION
Previously contained a number for DCIS incidence (0.21) but this is defined as a parameter in the main script so can use this directly in the function instead

Means if you change DCIS incidence in main script it will feed through. Does this look ok?