### PR TITLE
Sort out application of first year utility values

### DIFF
--- a/Gabriel's R code/ToyCostModel.R
+++ b/Gabriel's R code/ToyCostModel.R
@@ -1,5 +1,6 @@
 library(tidyverse)
 
+# read in and refactor data from Laudicella et al. (2016) https://doi.org/10.1038/bjc.2016.77
 tbl <- tribble(~Yr, ~Early_18.64, ~Late_18.64, ~Diff1, ~Early_65plus, ~Late_65plus, ~Diff2,
                0, 464, 607, 143, 1086, 1324, 238,
                1, 10746, 13315, 2569, 7597, 8804, 1207,
@@ -17,33 +18,143 @@ tbl <- tribble(~Yr, ~Early_18.64, ~Late_18.64, ~Diff1, ~Early_65plus, ~Late_65pl
                names_sep = "_",
                values_to = "Cost") %>%
   group_by(Stage, Age) %>%
-  mutate(DCost = Cost - first(Cost),
-         Yr1   = as.factor(Yr==1),
-         Yr2   = as.factor(Yr==2),
-         Yr3   = as.factor(Yr==3)) %>%
-  filter(Yr > 0) 
+  mutate(DCost      = Cost - first(Cost),
+         DCost.i    = DCost * 1.219312579, # NHSCII inflator for 2010/11-->2020/21
+         disc       = 1/1.035^(Yr-0.5),
+         DCost.i.d  = DCost.i * disc,
+         CDCost.i.d = cumsum(DCost.i.d),
+         Yr1        = as.factor(Yr==1),
+         Yr2        = as.factor(Yr==2),
+         Yr3        = as.factor(Yr==3)) %>%
+  filter(Yr > 0) %>%
+  arrange(Stage, Age, Yr)
 
+# log-linear model
 mod <- lm(data = tbl,
           formula = log(DCost) ~ (Yr1 + Yr2 + Yr3 + Yr) * Stage * Age)
 mod %>% AIC()
 
-tblNewDat <- crossing(Yr=1:15, Stage=c("Early", "Late"), Age=c("18.64", "65plus")) %>%
+# prediction matrix
+tblNewDat <- crossing(Yr=1:50, Stage=c("Early", "Late"), Age=c("18.64", "65plus")) %>%
+  mutate(Yr1 = as.factor(Yr==1),
+         Yr2 = as.factor(Yr==2),
+         Yr3 = as.factor(Yr==3))
+
+# generate predictions
+tblNewDat %>%
+  bind_cols(pred = mod %>% predict(newdata = tblNewDat)) %>%
+  mutate(DCost.p = exp(pred)) -> tblPred
+
+# make lookup table
+tblLookup <- tblPred %>%
+  group_by(Stage, Age) %>%
+  mutate(DCost.p.i    = DCost.p * 1.219312579, # NHSCII inflator for 2010/11-->2020/21
+         disc         = 1/1.035^(Yr-0.5),
+         DCost.p.i.d  = DCost.p.i * disc,
+         CDCost.p.i.d = cumsum(DCost.p.i.d)) %>%
+  arrange(Stage, Age, Yr) %>%
+  ungroup()
+
+# visualise fitted model
+tblPred %>%
+  ggplot() +
+  geom_line(aes(x=Yr, y=DCost.p, colour = interaction(Stage, Age)), size = 1, lty = 1) +
+  geom_point(data = tbl, aes(x=Yr, y=DCost, colour = interaction(Stage, Age)), size = 3)
+
+# visualise fitted model (cumulative, inflated, discounted costs)
+tblLookup %>%
+  ggplot() +
+  geom_line(aes(x=Yr, y=CDCost.p.i.d, colour = interaction(Stage, Age)), size = 1, lty = 1) +
+  geom_point(data = tbl, aes(x=Yr, y=CDCost.i.d, colour = interaction(Stage, Age)), size = 3)
+
+# function to generate expected discounted lifetime costs, given age & stage categories and life expectancy
+fnLookup_BCCosts <- function(iStage, iAge, iLE) {
+  as.numeric(tblLookup$CDCost.p.i.d[tblLookup$Stage==iStage & tblLookup$Age==iAge & tblLookup$Yr==iLE])
+}
+# example usage
+fnLookup_BCCosts("Early", "18.64", 12)
+
+
+## ==== alternative approaches explored but turned out slower ==== 
+
+modC <- lm(data = tbl,
+          formula = (CDCost.i.d) ~ (Yr1 + Yr2 + Yr3 + Yr) * Stage * Age)
+modC %>% AIC()
+
+tblNewDat <- crossing(Yr=1:50, Stage=c("Early", "Late"), Age=c("18.64", "65plus")) %>%
   mutate(Yr1 = as.factor(Yr==1),
          Yr2 = as.factor(Yr==2),
          Yr3 = as.factor(Yr==3))
 tblNewDat %>%
-  bind_cols(pred = mod %>% predict(newdata = tblNewDat)) %>%
-  mutate(DCost = exp(pred)) -> tblPred
+  bind_cols(pred = modC %>% predict(newdata = tblNewDat)) %>%
+  mutate(CDCost.i.d.p = (pred)) -> tblPredC
 
-tblPred %>%
-  ggplot(aes(x=Yr, y=DCost)) +
-  geom_line(aes(colour = interaction(Stage, Age)), size = 1, lty = 1) +
-  geom_point(data = tbl, aes(colour = interaction(Stage, Age)), size = 3)
+tblPredC %>%
+  ggplot() +
+  geom_line(aes(x=Yr, y=CDCost.i.d.p, colour = interaction(Stage, Age)), size = 1, lty = 1) +
+  geom_point(data = tbl, aes(x=Yr, y=CDCost.i.d, colour = interaction(Stage, Age)), size = 3)
 
-tblPred %>%
-  group_by(Stage, Age) %>%
-  mutate(DCost         = DCost * 1.219312579, # NHSCII inflator for 2010/11-->2020/21
-         disc          = 1/1.035^(Yr-0.5),
-         DCost.disc    = DCost * disc,
-         cumDCost.disc = cumsum(DCost.disc)) %>%
+
+tblPredC %>%
   arrange(Stage, Age, Yr)
+
+tblLookup %>%
+  ggplot() +
+  geom_line(aes(x=Yr, y=CDCost.p.i.d, colour = interaction(Stage, Age)), size = 1, lty = 1) +
+  geom_line(data = tblPredC, aes(x=Yr, y=CDCost.i.d.p, colour = interaction(Stage, Age)), size = 1, lty = 2) +
+  geom_point(data = tbl, aes(x=Yr, y=CDCost.i.d, colour = interaction(Stage, Age)), size = 3)
+
+fnLookupTidy <- function(iStage, iAge, iLE) {
+  tblLookup %>%
+    filter(Stage==iStage, Age==iAge, Yr==iLE) %>%
+    select(CDCost.p.i.d) %>%
+    as.numeric()
+}
+fnLookupTidy("Early", "18.64", 12)
+
+fnLookupBase <- function(iStage, iAge, iLE) {
+  as.numeric(tblLookup$CDCost.p.i.d[tblLookup$Stage==iStage & tblLookup$Age==iAge & tblLookup$Yr==iLE])
+}
+fnLookupBase("Early", "18.64", 12)
+
+library(data.table)
+data_table <- data.table(tblLookup)
+fnLookupDT <- function(iStage, iAge, iLE) {
+  data_table[Stage==iStage & Age==iAge & Yr==iLE]$CDCost.p.i.d
+}
+fnLookupDT("Early", "18.64", 12)
+
+setkey(data_table, Stage, Age, Yr)
+fnLookupDTi <- function(iStage, iAge, iLE) {
+  data_table[.(iStage, iAge, iLE), nomatch = 0L]$CDCost.p.i.d
+}
+fnLookupDTi("Early", "18.64", 12)
+
+fnModPred <- function(iStage, iAge, iLE) {
+  modC %>% predict(newdata = list(Stage=iStage, Age=iAge, Yr=iLE, Yr1 = as.factor(iLE==1),
+                                  Yr2 = as.factor(iLE==2),
+                                  Yr3 = as.factor(iLE==3))) %>%
+    as.numeric()
+}
+
+fnModPred("Early", "18.64", 12)
+
+fnModPred2 <- function(iStage, iAge, iLE) {
+  as.numeric(predict(modC, newdata = list(Stage=iStage, Age=iAge, Yr=iLE, Yr1 = as.factor(iLE==1),
+                                  Yr2 = as.factor(iLE==2),
+                                  Yr3 = as.factor(iLE==3))))
+}
+fnModPred2("Early", "18.64", 12)
+
+library(microbenchmark)
+tblTst <- tibble(iLE    = sample(x = 1:50, size = 100, replace = TRUE),
+                 iStage = sample(x = c("Early", "Late"), size = 100, replace = TRUE),
+                 iAge   = sample(x = c("18.64", "65plus"), size = 100, replace = TRUE))
+mbm <- microbenchmark(tblTst %>% pmap_dbl(fnLookupTidy),
+                      tblTst %>% pmap_dbl(fnLookupBase),
+                      tblTst %>% pmap_dbl(fnLookupDT),
+                      tblTst %>% pmap_dbl(fnLookupDTi),
+                      tblTst %>% pmap_dbl(fnModPred),
+                      tblTst %>% pmap_dbl(fnModPred2))
+mbm
+autoplot(mbm)


### PR DESCRIPTION
Have addressed the issue highlighted where the length of the QALY vector was set to end the year after someone died and utility was calculated for the whole year.

Bigger issue I found from this was that when someone gets cancer, the cancer utility is applied from the start of the year in which they're diagnosed. As a result I've made some fairly horrendous code to correct this. Essentially what it does is apply the utility for treating cancer of a given NPI in the first year for the proportion of the year in which they have cancer. Then in the second year it also applies the first year utility for the proportion of the year that is within 1 year of the cancer diagnosis and the follow on utility for the rest of that year.

Given how complex this code is could one of you have a check to see if it makes sense? 